### PR TITLE
Move history and last move rule

### DIFF
--- a/lib/Errors.js
+++ b/lib/Errors.js
@@ -9,10 +9,6 @@ class InvalidMoveError extends InvalidInputError {
 	constructor(message = 'The given move is invalid.') { super(message); }
 }
 
-class IllegalMoveError extends InvalidInputError {
-	constructor(message = 'The given move is not possible.') { super(message); }
-}
-
 class NotFoundError extends ApplicationError {
 	status() { return 404; }
 }
@@ -21,6 +17,5 @@ module.exports = {
 	ApplicationError,
 	InvalidInputError,
 	InvalidMoveError,
-	IllegalMoveError,
 	NotFoundError,
 };

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -1,7 +1,7 @@
 const { nanoid } = require('nanoid');
 const { Board } = require('./Board');
 const { BoardFactory } = require('./BoardFactory');
-const { InvalidMoveError, IllegalMoveError, NotFoundError } = require('./Errors');
+const { InvalidMoveError, NotFoundError } = require('./Errors');
 const { GameModel } = require('./models/Games.model');
 
 const PHASES = Object.freeze({
@@ -82,7 +82,7 @@ module.exports = (Model = new GameModel()) => {
 				throw new InvalidMoveError();
 			}
 			if (!board.canMoveTokenTo(from, to)) {
-				throw new IllegalMoveError();
+				throw new InvalidMoveError();
 			}
 			board.moveToken(from, to);
 			if (this.state.board.isWon()) {
@@ -105,11 +105,11 @@ module.exports = (Model = new GameModel()) => {
 			if (this.state.turn > 0) {
 				const lastMove = this.state.movedDiscs[this.state.turn - 1];
 				if (lastMove.to.x === from.x && lastMove.to.y === from.y) {
-					throw new IllegalMoveError('You cannot move your opponent\'s last moved disc.');
+					throw new InvalidMoveError('You cannot move your opponent\'s last moved disc.');
 				}
 			}
 			if (!board.canMoveDiscTo(from, to)) {
-				throw new IllegalMoveError();
+				throw new InvalidMoveError();
 			}
 			board.moveDisc(from, to);
 			this.state.phase = PHASES.INITIAL;

--- a/lib/Game.js
+++ b/lib/Game.js
@@ -23,6 +23,7 @@ module.exports = (Model = new GameModel()) => {
 			this.friendlyName = friendlyName;
 			this.state = {
 				turn: 0,
+				movedDiscs: [],
 				phase: PHASES.INITIAL,
 				...state,
 			};
@@ -101,12 +102,19 @@ module.exports = (Model = new GameModel()) => {
 			if (!disc || this.state.phase !== PHASES.MID_MOVE) {
 				throw new InvalidMoveError();
 			}
+			if (this.state.turn > 0) {
+				const lastMove = this.state.movedDiscs[this.state.turn - 1];
+				if (lastMove.to.x === from.x && lastMove.to.y === from.y) {
+					throw new IllegalMoveError('You cannot move your opponent\'s last moved disc.');
+				}
+			}
 			if (!board.canMoveDiscTo(from, to)) {
 				throw new IllegalMoveError();
 			}
 			board.moveDisc(from, to);
 			this.state.phase = PHASES.INITIAL;
 			this.state.turn += 1;
+			this.state.movedDiscs.push({ from, to });
 			this.save();
 			return this;
 		}

--- a/lib/Game.test.js
+++ b/lib/Game.test.js
@@ -259,6 +259,18 @@ describe('Game', () => {
 				game.moveToken({ from: { x: 0, y: -2 }, to: { x: 1, y: -1 } });
 				expect(game.state.winner).toEqual('Player0');
 			});
+
+			it('doesn\'t allow moving the last moved disc in the following turn', () => {
+				const game = new Game({ players: ['Player0', 'Player1'] });
+				expect(game.state.winner).toBe(undefined);
+
+				game.moveToken({ from: { x: -2, y: 0 }, to: { x: 1, y: 0 } });
+				game.moveDisc({ from: { x: -2, y: 0 }, to: { x: 2, y: -1 } });
+				expect(game.state.winner).toBe(undefined);
+
+				game.moveToken({ from: { x: -2, y: -2 }, to: { x: -2, y: -1 } });
+				expect(() => game.moveDisc({ from: { x: 2, y: -1 }, to: { x: -2, y: 0 } })).toThrow(IllegalMoveError);
+			});
 		});
 	});
 });

--- a/lib/Game.test.js
+++ b/lib/Game.test.js
@@ -1,6 +1,6 @@
 const gameModule = require('./Game');
 const { GamesModelMock } = require('./models/Games.mock');
-const { NotFoundError, InvalidMoveError, IllegalMoveError } = require('./Errors');
+const { NotFoundError, InvalidMoveError } = require('./Errors');
 
 describe('Game', () => {
 	describe('dependency injection', () => {
@@ -135,10 +135,10 @@ describe('Game', () => {
 					.toThrow(InvalidMoveError);
 			});
 
-			it('throws IllegalMoveError for illegal moves of a valid token', () => {
+			it('throws InvalidMoveError for illegal moves of a valid token', () => {
 				const game = new Game({});
 				expect(() => game.moveToken({ from: { x: -2, y: 0 }, to: { x: -4, y: -4 } }))
-					.toThrow(IllegalMoveError); // not a valid target for this token
+					.toThrow(InvalidMoveError); // not a valid target for this token
 			});
 
 			it('doesn\'t allow to move a token twice in a row', () => {
@@ -183,19 +183,19 @@ describe('Game', () => {
 			it('doesn\'t allow moving discs to invalid locations', () => {
 				const game = new Game({ gamestate: { phase: GamePhases.MID_MOVE } });
 				expect(() => game.moveDisc({ from: { x: -2, y: -1 }, to: { x: 2, y: 4 } }))
-					.toThrow(IllegalMoveError);
+					.toThrow(InvalidMoveError);
 			});
 
 			it('doesn\'t allow moving unmoveable discs', () => {
 				const game = new Game({ gamestate: { phase: GamePhases.MID_MOVE } });
 				expect(() => game.moveDisc({ from: { x: -2, y: -2 }, to: { x: 2, y: 3 } }))
-					.toThrow(IllegalMoveError);
+					.toThrow(InvalidMoveError);
 			});
 
 			it('doesn\'t allow moving discs to locations only attached to one other disc', () => {
 				const game = new Game({ gamestate: { phase: GamePhases.MID_MOVE } });
 				expect(() => game.moveDisc({ from: { x: -2, y: -1 }, to: { x: 3, y: 3 } }))
-					.toThrow(IllegalMoveError);
+					.toThrow(InvalidMoveError);
 			});
 		});
 
@@ -269,7 +269,7 @@ describe('Game', () => {
 				expect(game.state.winner).toBe(undefined);
 
 				game.moveToken({ from: { x: -2, y: -2 }, to: { x: -2, y: -1 } });
-				expect(() => game.moveDisc({ from: { x: 2, y: -1 }, to: { x: -2, y: 0 } })).toThrow(IllegalMoveError);
+				expect(() => game.moveDisc({ from: { x: 2, y: -1 }, to: { x: -2, y: 0 } })).toThrow(InvalidMoveError);
 			});
 		});
 	});

--- a/public/scripts/game.js
+++ b/public/scripts/game.js
@@ -1,6 +1,5 @@
 class Game {
 	constructor(data) {
-		console.log(data);
 		this.cheatArray = [];
 		this.state = data.gamestate;
 		this.players = data.players;
@@ -33,8 +32,17 @@ class Game {
 		this.playerTokens = board.players;
 
 		const uniqueGhostDiscs = new Set();
+		let lastMovedDisc = {};
+
+		if (this.state.turn > 0) {
+			lastMovedDisc = this.state.movedDiscs[this.state.turn - 1];
+		}
 
 		board.discs.forEach((d) => {
+			if (d.moveable && d.x === lastMovedDisc.to.x && d.y === lastMovedDisc.to.y) {
+				d.moveable = false;
+				d.moveableTo = [];
+			}
 			this.discs.push(new Disc(d.x * 120 + (d.y * -60) + 500, d.y * 100 + 500, 80, d));
 
 			d.moveableTo.forEach((ghostDisc) => uniqueGhostDiscs.add(JSON.stringify(ghostDisc)));

--- a/public/shapes/disc.js
+++ b/public/shapes/disc.js
@@ -17,7 +17,7 @@ class Disc {
 		}
 		ellipse(this.x, this.y, this.d);
 
-		if (game.phase === 'mid_move' && this.discInfo.moveable) {
+		if (game.state.phase === 'mid_move' && this.discInfo.moveable) {
 			const dotWeight = this.hovering || this.clicked ? 3.5 : 2;
 			fill('black');
 			for (let i = 0; i < 3; i++) {

--- a/public/shapes/hud.js
+++ b/public/shapes/hud.js
@@ -45,10 +45,10 @@ class Hud {
 		}
 
 		// draws hints in start phase
-		if (game.gameHistory.length < 3 && !this.winner) {
+		if (game.state.turn < 3 && !this.winner) {
 			fill('#BBB');
 			textSize(map(sin(frameCount * 0.02), -20, 1, 45, 25));
-			text(`Move a ${hints[game.phase]}`, 25, 120);
+			text(`Move a ${hints[game.state.phase]}`, 25, 120);
 		}
 		stroke('black');
 	}


### PR DESCRIPTION
- disallows moving the opponent's last moved disc (the last missing rule) both in the backend and the frontend.
- adds `movedDiscs` array to game state